### PR TITLE
Fix: remove git clean -fd step to avoid pbf rewriting

### DIFF
--- a/.github/workflows/DeployingProduction.yml
+++ b/.github/workflows/DeployingProduction.yml
@@ -29,7 +29,6 @@ jobs:
             
             # Новый шаг: сброс локальных изменений
             git reset --hard
-            git clean -fd
             
             # Выполнение pull после очистки
             git pull https://${{ secrets.PUNKER_GITHUB_USERNAME }}:${{ secrets.PUNKER_ACCESS_TOKEN }}@github.com/${{ github.repository }}.git main


### PR DESCRIPTION
Мы можем использовать кастомные файлы `*.pbf` и шаг с очисткой может перезаписать соответствующие `*.pbf`, github не позволяет загружать большие файлы, поэтому на этапе `git pull` это нужно учитывать.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Новые функции**
	- Обновлена конфигурация рабочего процесса для автоматического развертывания в продакшн при закрытии пулл-реквестов.
	- Добавлены новые переменные окружения для настройки контейнеров.
- **Изменения**
	- Удаление существующих контейнеров и создание новых с использованием обновленных команд Docker Compose.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->